### PR TITLE
Add helper methods to parse config directly into an F[_]

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,18 @@ res2: Either[io.circe.Error,AppSettings] = Right(AppSettings(HttpSettings(Server
 
 Based on this [application.conf].
 
- [application.conf]: https://github.com/circe/circe-config/tree/master/src/test/resources/application.conf
+If you are working in something like `cats.effect.IO`, or some other type `F[_]` that provides a
+`cats.ApplicativeError[F, Throwable]`, you can use the following, with the same imports as above:
+
+```scala
+import cats.implicits._, cats.effect.IO
+import io.circe.config._
+val cfg : IO[AppSettings] = loadConfigF[IO, AppSettings]
+```
+
+This makes the configuration directly available in your `F[_]` such as IO, which handles any errors.
+
+[application.conf]: https://github.com/circe/circe-config/tree/master/src/test/resources/application.conf
 
 ## Contributing
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-feature",
   "-language:postfixOps",
+  "-language:higherKinds",
   "-unchecked",
   "-Xfuture",
   "-Ywarn-dead-code",

--- a/src/main/scala/io.circe.config/package.scala
+++ b/src/main/scala/io.circe.config/package.scala
@@ -15,8 +15,13 @@
  */
 package io.circe
 
+import cats.ApplicativeError
+import cats.instances.either._
+import cats.syntax.bifunctor._
+import cats.syntax.either._
 import com.typesafe.config._
 import scala.collection.JavaConverters._
+import config.syntax._
 
 /**
  * circe-config: A [[https://github.com/lightbend/config Typesafe config]]
@@ -54,6 +59,11 @@ import scala.collection.JavaConverters._
  * }}}
  */
 package object config {
+  def loadConfigF[F[_], C : Decoder](implicit ev : ApplicativeError[F, Throwable]) : F[C] =
+    ConfigFactory.load().as[C].leftWiden[Throwable].raiseOrPure[F]
+
+  def loadConfigF[F[_], C : Decoder](path : String)(implicit ev : ApplicativeError[F, Throwable]) : F[C] =
+    ConfigFactory.load().as[C](path).leftWiden[Throwable].raiseOrPure[F]
 
   private[config] def jsonToConfigValue(json: Json): ConfigValue =
     json.fold(


### PR DESCRIPTION
This uses `ApplicativeError[F[_], Throwable]`, which is available on many cats types such as `IO`, `Either[Throwable, ?]`, etc.

So now you can just do:

```
val cfg : AppSettings = loadConfig[IO, AppSettings].unsafeRunSync()
```

Inspired from [pureconfig with cats-effect](https://github.com/pureconfig/pureconfig/blob/7b315536081c542bee37bd680495e8143252d577/modules/cats-effect/src/main/scala/pureconfig/module/catseffect/package.scala#L34) 
