### PR TITLE
Fix decoding single config values

### DIFF
--- a/src/main/scala/io.circe.config/parser.scala
+++ b/src/main/scala/io.circe.config/parser.scala
@@ -97,11 +97,13 @@ object parser extends Parser {
       .catchNonFatal {
         convertValueUnsafe {
           val config = parseConfig
-          path.fold(config) {
-            path =>
-              if (config.hasPath(path)) config.getConfig(path)
+          path match {
+            case Some(path) =>
+              if (config.hasPath(path)) config.getValue(path)
               else throw new ParsingFailure("Path not found in config", new ConfigException.Missing(path))
-          }.root
+            case _ =>
+              config.root
+          }
         }
       }
       .leftMap(error => ParsingFailure(error.getMessage, error))

--- a/src/test/scala/io.circe.config/CirceConfigSpec.scala
+++ b/src/test/scala/io.circe.config/CirceConfigSpec.scala
@@ -65,6 +65,10 @@ class CirceConfigSpec extends AnyFlatSpec with Matchers {
     parser.decode[AppSettings]().fold(fail(_), _ should equal (DecodedAppSettings))
   }
 
+  it should "parse and decode config value from default typesafe config resolution with path" in {
+    parser.decodePath[Double]("http.version").fold(fail(_), _ should equal (DecodedAppSettings.http.version))
+  }
+
   it should "parse and decode config from default typesafe config resolution via ApplicativeError" in {
     parser.decodeF[IO, AppSettings]().unsafeRunSync() should equal (DecodedAppSettings)
   }


### PR DESCRIPTION
Decoding configuration keys one by one, in contrast to decoding the whole thing into a case class, always results in an error. The problem stems from the `Config#root` call in the `toJson` method in the parser, where a pathed Config may hold a string, and int, etc., and thus is not a ConfigObject. The fix is to call `Config#getValue(path)` when the path is present, and `Config#root` otherwise.